### PR TITLE
Support setMultihash and multihash on PublicResolver

### DIFF
--- a/contracts/PublicResolver.sol
+++ b/contracts/PublicResolver.sol
@@ -22,7 +22,7 @@ contract PublicResolver {
     event NameChanged(bytes32 indexed node, string name);
     event ABIChanged(bytes32 indexed node, uint256 indexed contentType);
     event PubkeyChanged(bytes32 indexed node, bytes32 x, bytes32 y);
-    event TextChanged(bytes32 indexed node, string indexed indexedKey, string key);
+    event TextChanged(bytes32 indexed node, string indexedKey, string key);
     event MultihashChanged(bytes32 indexed node, bytes hash);
 
     struct PublicKey {

--- a/contracts/PublicResolver.sol
+++ b/contracts/PublicResolver.sol
@@ -232,7 +232,7 @@ contract PublicResolver {
         interfaceID == ABI_INTERFACE_ID ||
         interfaceID == PUBKEY_INTERFACE_ID ||
         interfaceID == TEXT_INTERFACE_ID ||
-        interfaceID == INTERFACE_META_ID ||
-        interfaceID == MULTIHASH_INTERFACE_ID;
+        interfaceID == MULTIHASH_INTERFACE_ID ||
+        interfaceID == INTERFACE_META_ID;
     }
 }

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -434,7 +434,7 @@ contract('PublicResolver', function (accounts) {
         it('returns empty when fetching nonexistent multihash', async () => {
             assert.equal(
                 await resolver.multihash(node),
-                '0x0000000000000000000000000000000000000000000000000000000000000000'
+                '0x'
             );
         });
     });

--- a/test/TestPublicResolver.js
+++ b/test/TestPublicResolver.js
@@ -394,7 +394,7 @@ contract('PublicResolver', function (accounts) {
         });
 
         it('can overwrite previously set multihash', async () => {
-            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[0]});
+            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
             assert.equal(await resolver.multihash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
 
             await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000002', {from: accounts[0]});
@@ -402,16 +402,16 @@ contract('PublicResolver', function (accounts) {
         });
 
         it('can overwrite to same multihash', async () => {
-            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[0]});
-            assert.equal(await resolver.multihash(node), '0x0000000000000000000000000000000000000000000000000000000000000000');
+            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
+            assert.equal(await resolver.multihash(node), '0x0000000000000000000000000000000000000000000000000000000000000001');
 
-            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[0]});
-            assert.equal(await resolver.multihash(node), '0x0000000000000000000000000000000000000000000000000000000000000000');
+            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000002', {from: accounts[0]});
+            assert.equal(await resolver.multihash(node), '0x0000000000000000000000000000000000000000000000000000000000000002');
         });
 
         it('forbids setting multihash by non-owners', async () => {
             try {
-                await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[1]});
+                await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[1]});
             } catch (error) {
                 return utils.ensureException(error);
             }
@@ -420,10 +420,10 @@ contract('PublicResolver', function (accounts) {
         });
 
         it('forbids writing same multihash by non-owners', async () => {
-            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[0]});
+            await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[0]});
 
             try {
-                await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000000', {from: accounts[1]});
+                await resolver.setMultihash(node, '0x0000000000000000000000000000000000000000000000000000000000000001', {from: accounts[1]});
             } catch (error) {
                 return utils.ensureException(error);
             }


### PR DESCRIPTION
- Implement `multihash` and `setMultihash` on `PublicResolver.sol` with [EIP-1062](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1062.md)
- Implement test cases on `multihash`