### PR TITLE
Add ENS library

### DIFF
--- a/contracts/TestENSLib.sol
+++ b/contracts/TestENSLib.sol
@@ -4,10 +4,9 @@ import './libs/ENSLib.sol';
 
 
 /**
- * A registrar that allocates subdomains to the first person to claim them, but
- * expires registrations a fixed period after they're initially claimed.
+ * A contract to test the ENSLibrary with a on chain implementation
  */
-contract TestRegistryLib {
+contract TestENSLib {
     using ENSLib for *;
 
     address public ensAddr;
@@ -17,7 +16,7 @@ contract TestRegistryLib {
      * Constructor.
      * @param _ensAddr The address of the ENS registry.
      */
-    function TestRegistryLib(address _ensAddr) {
+    function TestENSLib(address _ensAddr) {
         ensAddr = _ensAddr;
     }
 
@@ -27,7 +26,7 @@ contract TestRegistryLib {
      * @return address of the owner.
      */
     function owner(bytes32 node) public view returns (address) {
-      return node.owner(ensAddr);
+        return node.owner(ensAddr);
     }
 
     /**
@@ -36,7 +35,7 @@ contract TestRegistryLib {
      * @return address of the resolver.
      */
     function resolver(bytes32 node) public view returns (address) {
-      return node.resolver(ensAddr);
+        return node.resolver(ensAddr);
     }
 
     /**
@@ -45,7 +44,7 @@ contract TestRegistryLib {
      * @return ttl of the node.
      */
     function ttl(bytes32 node) public view returns (uint64) {
-      return node.ttl(ensAddr);
+        return node.ttl(ensAddr);
     }
 
     /**
@@ -54,7 +53,7 @@ contract TestRegistryLib {
      * @return address of the owner.
      */
     function ownerByENSName(string ensName) public view returns (address) {
-      return ensName.owner(ensAddr);
+        return ensName.owner(ensAddr);
     }
 
     /**
@@ -63,7 +62,7 @@ contract TestRegistryLib {
      * @return resolver of the ens.
      */
     function resolverByENSName(string ensName) public view returns (address) {
-      return ensName.resolver(ensAddr);
+        return ensName.resolver(ensAddr);
     }
 
     /**
@@ -72,7 +71,7 @@ contract TestRegistryLib {
      * @return ttl of the ens.
      */
     function ttlByENSName(string ensName) public view returns (uint64) {
-      return ensName.ttl(ensAddr);
+        return ensName.ttl(ensAddr);
     }
 
     /**
@@ -80,6 +79,6 @@ contract TestRegistryLib {
      * @param ensName The name of the ens to hash
      */
     function hashname(string ensName) public view returns (bytes32){
-      return ensName.hashname();
+        return ensName.hashname();
     }
 }

--- a/contracts/TestRegistryLib.sol
+++ b/contracts/TestRegistryLib.sol
@@ -54,8 +54,7 @@ contract TestRegistryLib {
      * @return address of the owner.
      */
     function ownerByENSName(string ensName) public view returns (address) {
-      bytes32 node = ensName.hashname();
-      return node.owner(ensAddr);
+      return ensName.owner(ensAddr);
     }
 
     /**

--- a/contracts/TestRegistryLib.sol
+++ b/contracts/TestRegistryLib.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.4.22;
+
+import './libs/ENSLib.sol';
+
+
+/**
+ * A registrar that allocates subdomains to the first person to claim them, but
+ * expires registrations a fixed period after they're initially claimed.
+ */
+contract TestRegistryLib {
+    using ENSLib for *;
+
+    address public ensAddr;
+
+
+    /**
+     * Constructor.
+     * @param _ensAddr The address of the ENS registry.
+     */
+    function TestRegistryLib(address _ensAddr) {
+        ensAddr = _ensAddr;
+    }
+
+    /**
+     * @dev Returns the address that owns the specified node.
+     * @param node The specified node.
+     * @return address of the owner.
+     */
+    function owner(bytes32 node) public view returns (address) {
+      return node.owner(ensAddr);
+    }
+
+    /**
+     * @dev Returns the address of the resolver for the specified node.
+     * @param node The specified node.
+     * @return address of the resolver.
+     */
+    function resolver(bytes32 node) public view returns (address) {
+      return node.resolver(ensAddr);
+    }
+
+    /**
+     * @dev Returns the TTL of a node, and any records associated with it.
+     * @param node The specified node.
+     * @return ttl of the node.
+     */
+    function ttl(bytes32 node) public view returns (uint64) {
+      return node.ttl(ensAddr);
+    }
+
+    /**
+     * @dev Returns the address that owns the specified ens.
+     * @param ensName The specified ens.
+     * @return address of the owner.
+     */
+    function ownerByENSName(string ensName) public view returns (address) {
+      bytes32 node = ensName.hashname();
+      return node.owner(ensAddr);
+    }
+
+    /**
+     * Get the hash of an ens by his name
+     * @param ensName The name of the ens to hash
+     */
+    function hashname(string ensName) public view returns (bytes32){
+      return ensName.hashname();
+    }
+}

--- a/contracts/TestRegistryLib.sol
+++ b/contracts/TestRegistryLib.sol
@@ -58,6 +58,24 @@ contract TestRegistryLib {
     }
 
     /**
+     * @dev Returns the address of the resolver for the specified ens.
+     * @param ensName The specified ens.
+     * @return resolver of the ens.
+     */
+    function resolverByENSName(string ensName) public view returns (address) {
+      return ensName.resolver(ensAddr);
+    }
+
+    /**
+     * @dev Returns the TTL of a ens, and any records associated with it.
+     * @param ensName The specified ens.
+     * @return ttl of the ens.
+     */
+    function ttlByENSName(string ensName) public view returns (uint64) {
+      return ensName.ttl(ensAddr);
+    }
+
+    /**
      * Get the hash of an ens by his name
      * @param ensName The name of the ens to hash
      */

--- a/contracts/libs/ENSLib.sol
+++ b/contracts/libs/ENSLib.sol
@@ -4,7 +4,14 @@ import '../ENS.sol';
 import './strings.sol';
 
 /**
- * The ENS library.
+ * @title ENS utility library for Solidity contracts.
+ * @author Augusto Lemble <me@augustolemble.com>
+ *
+ * @dev This library allows the access to ens information by their name.
+ *      It uses the strings library to split the string of the ens name and
+ *      generate the namehash of it.
+ *      Once the namehash of the ens is available it only need the address of
+ *      the ENS registry to get the ens information.
  */
 library ENSLib {
   using strings for *;
@@ -77,7 +84,7 @@ library ENSLib {
         parts[i] = s.split(delim).toString();
     }
 
-    // Generate teh hash from teh labels
+    // Generate the hash from the labels
     bytes32 nodeHash = bytes32(0);
     bytes32 labelHash;
     for(i = parts.length; i > 0; i--) {

--- a/contracts/libs/ENSLib.sol
+++ b/contracts/libs/ENSLib.sol
@@ -37,6 +37,33 @@ library ENSLib {
   }
 
   /**
+   * @dev Returns the address that owns the specified ens.
+   * @param ensName The specified ens name.
+   * @return address of the owner.
+   */
+  function owner(string ensName, address ensAddress) public view returns (address) {
+    return ENS(ensAddress).owner(hashname(ensName));
+  }
+
+  /**
+   * @dev Returns the address of the resolver for the specified ens.
+   * @param ensName The specified ens name.
+   * @return address of the resolver.
+   */
+  function resolver(string ensName, address ensAddress) public view returns (address) {
+    return ENS(ensAddress).resolver(hashname(ensName));
+  }
+
+  /**
+   * @dev Returns the TTL of a ens, and any records associated with it.
+   * @param ensName The specified ens name.
+   * @return ttl of the node.
+   */
+  function ttl(string ensName, address ensAddress) public view returns (uint64) {
+    return ENS(ensAddress).ttl(hashname(ensName));
+  }
+
+  /**
    * Get the hash of an ens by his name
    * @param ensName The name of the ens to hash
    */

--- a/contracts/libs/ENSLib.sol
+++ b/contracts/libs/ENSLib.sol
@@ -1,0 +1,64 @@
+pragma solidity ^0.4.18;
+
+import '../ENS.sol';
+import './strings.sol';
+
+/**
+ * The ENS library.
+ */
+library ENSLib {
+  using strings for *;
+
+  /**
+   * @dev Returns the address that owns the specified node.
+   * @param node The specified node.
+   * @return address of the owner.
+   */
+  function owner(bytes32 node, address ensAddress) public view returns (address) {
+    return ENS(ensAddress).owner(node);
+  }
+
+  /**
+   * @dev Returns the address of the resolver for the specified node.
+   * @param node The specified node.
+   * @return address of the resolver.
+   */
+  function resolver(bytes32 node, address ensAddress) public view returns (address) {
+    return ENS(ensAddress).resolver(node);
+  }
+
+  /**
+   * @dev Returns the TTL of a node, and any records associated with it.
+   * @param node The specified node.
+   * @return ttl of the node.
+   */
+  function ttl(bytes32 node, address ensAddress) public view returns (uint64) {
+    return ENS(ensAddress).ttl(node);
+  }
+
+  /**
+   * Get the hash of an ens by his name
+   * @param ensName The name of the ens to hash
+   */
+  function hashname(string ensName) public view returns (bytes32){
+
+    // Split the name in labes
+    var s = ensName.toSlice();
+    var delim = ".".toSlice();
+    var parts = new string[](s.count(delim) + 1);
+    for(uint i = 0; i < parts.length; i++) {
+        parts[i] = s.split(delim).toString();
+    }
+
+    // Generate teh hash from teh labels
+    bytes32 nodeHash = bytes32(0);
+    bytes32 labelHash;
+    for(i = parts.length; i > 0; i--) {
+        labelHash = keccak256(parts[i-1]);
+        nodeHash = keccak256(nodeHash, labelHash);
+    }
+
+    return nodeHash;
+  }
+
+}

--- a/contracts/libs/strings.sol
+++ b/contracts/libs/strings.sol
@@ -1,0 +1,718 @@
+/*
+ * @title String & slice utility library for Solidity contracts.
+ * @author Nick Johnson <arachnid@notdot.net>
+ *
+ * @dev Functionality in this library is largely implemented using an
+ *      abstraction called a 'slice'. A slice represents a part of a string -
+ *      anything from the entire string to a single character, or even no
+ *      characters at all (a 0-length slice). Since a slice only has to specify
+ *      an offset and a length, copying and manipulating slices is a lot less
+ *      expensive than copying and manipulating the strings they reference.
+ *
+ *      To further reduce gas costs, most functions on slice that need to return
+ *      a slice modify the original one instead of allocating a new one; for
+ *      instance, `s.split(".")` will return the text up to the first '.',
+ *      modifying s to only contain the remainder of the string after the '.'.
+ *      In situations where you do not want to modify the original slice, you
+ *      can make a copy first with `.copy()`, for example:
+ *      `s.copy().split(".")`. Try and avoid using this idiom in loops; since
+ *      Solidity has no memory management, it will result in allocating many
+ *      short-lived slices that are later discarded.
+ *
+ *      Functions that return two slices come in two versions: a non-allocating
+ *      version that takes the second slice as an argument, modifying it in
+ *      place, and an allocating version that allocates and returns the second
+ *      slice; see `nextRune` for example.
+ *
+ *      Functions that have to copy string data will return strings rather than
+ *      slices; these can be cast back to slices for further processing if
+ *      required.
+ *
+ *      For convenience, some functions are provided with non-modifying
+ *      variants that create a new slice and return both; for instance,
+ *      `s.splitNew('.')` leaves s unmodified, and returns two values
+ *      corresponding to the left and right parts of the string.
+ */
+
+pragma solidity ^0.4.14;
+
+library strings {
+    struct slice {
+        uint _len;
+        uint _ptr;
+    }
+
+    function memcpy(uint dest, uint src, uint len) private pure {
+        // Copy word-length chunks while possible
+        for(; len >= 32; len -= 32) {
+            assembly {
+                mstore(dest, mload(src))
+            }
+            dest += 32;
+            src += 32;
+        }
+
+        // Copy remaining bytes
+        uint mask = 256 ** (32 - len) - 1;
+        assembly {
+            let srcpart := and(mload(src), not(mask))
+            let destpart := and(mload(dest), mask)
+            mstore(dest, or(destpart, srcpart))
+        }
+    }
+
+    /*
+     * @dev Returns a slice containing the entire string.
+     * @param self The string to make a slice from.
+     * @return A newly allocated slice containing the entire string.
+     */
+    function toSlice(string self) internal pure returns (slice) {
+        uint ptr;
+        assembly {
+            ptr := add(self, 0x20)
+        }
+        return slice(bytes(self).length, ptr);
+    }
+
+    /*
+     * @dev Returns the length of a null-terminated bytes32 string.
+     * @param self The value to find the length of.
+     * @return The length of the string, from 0 to 32.
+     */
+    function len(bytes32 self) internal pure returns (uint) {
+        uint ret;
+        if (self == 0)
+            return 0;
+        if (self & 0xffffffffffffffffffffffffffffffff == 0) {
+            ret += 16;
+            self = bytes32(uint(self) / 0x100000000000000000000000000000000);
+        }
+        if (self & 0xffffffffffffffff == 0) {
+            ret += 8;
+            self = bytes32(uint(self) / 0x10000000000000000);
+        }
+        if (self & 0xffffffff == 0) {
+            ret += 4;
+            self = bytes32(uint(self) / 0x100000000);
+        }
+        if (self & 0xffff == 0) {
+            ret += 2;
+            self = bytes32(uint(self) / 0x10000);
+        }
+        if (self & 0xff == 0) {
+            ret += 1;
+        }
+        return 32 - ret;
+    }
+
+    /*
+     * @dev Returns a slice containing the entire bytes32, interpreted as a
+     *      null-terminated utf-8 string.
+     * @param self The bytes32 value to convert to a slice.
+     * @return A new slice containing the value of the input argument up to the
+     *         first null.
+     */
+    function toSliceB32(bytes32 self) internal pure returns (slice ret) {
+        // Allocate space for `self` in memory, copy it there, and point ret at it
+        assembly {
+            let ptr := mload(0x40)
+            mstore(0x40, add(ptr, 0x20))
+            mstore(ptr, self)
+            mstore(add(ret, 0x20), ptr)
+        }
+        ret._len = len(self);
+    }
+
+    /*
+     * @dev Returns a new slice containing the same data as the current slice.
+     * @param self The slice to copy.
+     * @return A new slice containing the same data as `self`.
+     */
+    function copy(slice self) internal pure returns (slice) {
+        return slice(self._len, self._ptr);
+    }
+
+    /*
+     * @dev Copies a slice to a new string.
+     * @param self The slice to copy.
+     * @return A newly allocated string containing the slice's text.
+     */
+    function toString(slice self) internal pure returns (string) {
+        string memory ret = new string(self._len);
+        uint retptr;
+        assembly { retptr := add(ret, 32) }
+
+        memcpy(retptr, self._ptr, self._len);
+        return ret;
+    }
+
+    /*
+     * @dev Returns the length in runes of the slice. Note that this operation
+     *      takes time proportional to the length of the slice; avoid using it
+     *      in loops, and call `slice.empty()` if you only need to know whether
+     *      the slice is empty or not.
+     * @param self The slice to operate on.
+     * @return The length of the slice in runes.
+     */
+    function len(slice self) internal pure returns (uint l) {
+        // Starting at ptr-31 means the LSB will be the byte we care about
+        uint ptr = self._ptr - 31;
+        uint end = ptr + self._len;
+        for (l = 0; ptr < end; l++) {
+            uint8 b;
+            assembly { b := and(mload(ptr), 0xFF) }
+            if (b < 0x80) {
+                ptr += 1;
+            } else if(b < 0xE0) {
+                ptr += 2;
+            } else if(b < 0xF0) {
+                ptr += 3;
+            } else if(b < 0xF8) {
+                ptr += 4;
+            } else if(b < 0xFC) {
+                ptr += 5;
+            } else {
+                ptr += 6;
+            }
+        }
+    }
+
+    /*
+     * @dev Returns true if the slice is empty (has a length of 0).
+     * @param self The slice to operate on.
+     * @return True if the slice is empty, False otherwise.
+     */
+    function empty(slice self) internal pure returns (bool) {
+        return self._len == 0;
+    }
+
+    /*
+     * @dev Returns a positive number if `other` comes lexicographically after
+     *      `self`, a negative number if it comes before, or zero if the
+     *      contents of the two slices are equal. Comparison is done per-rune,
+     *      on unicode codepoints.
+     * @param self The first slice to compare.
+     * @param other The second slice to compare.
+     * @return The result of the comparison.
+     */
+    function compare(slice self, slice other) internal pure returns (int) {
+        uint shortest = self._len;
+        if (other._len < self._len)
+            shortest = other._len;
+
+        uint selfptr = self._ptr;
+        uint otherptr = other._ptr;
+        for (uint idx = 0; idx < shortest; idx += 32) {
+            uint a;
+            uint b;
+            assembly {
+                a := mload(selfptr)
+                b := mload(otherptr)
+            }
+            if (a != b) {
+                // Mask out irrelevant bytes and check again
+                uint256 mask = uint256(-1); // 0xffff...
+                if(shortest < 32) {
+                  mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
+                }
+                uint256 diff = (a & mask) - (b & mask);
+                if (diff != 0)
+                    return int(diff);
+            }
+            selfptr += 32;
+            otherptr += 32;
+        }
+        return int(self._len) - int(other._len);
+    }
+
+    /*
+     * @dev Returns true if the two slices contain the same text.
+     * @param self The first slice to compare.
+     * @param self The second slice to compare.
+     * @return True if the slices are equal, false otherwise.
+     */
+    function equals(slice self, slice other) internal pure returns (bool) {
+        return compare(self, other) == 0;
+    }
+
+    /*
+     * @dev Extracts the first rune in the slice into `rune`, advancing the
+     *      slice to point to the next rune and returning `self`.
+     * @param self The slice to operate on.
+     * @param rune The slice that will contain the first rune.
+     * @return `rune`.
+     */
+    function nextRune(slice self, slice rune) internal pure returns (slice) {
+        rune._ptr = self._ptr;
+
+        if (self._len == 0) {
+            rune._len = 0;
+            return rune;
+        }
+
+        uint l;
+        uint b;
+        // Load the first byte of the rune into the LSBs of b
+        assembly { b := and(mload(sub(mload(add(self, 32)), 31)), 0xFF) }
+        if (b < 0x80) {
+            l = 1;
+        } else if(b < 0xE0) {
+            l = 2;
+        } else if(b < 0xF0) {
+            l = 3;
+        } else {
+            l = 4;
+        }
+
+        // Check for truncated codepoints
+        if (l > self._len) {
+            rune._len = self._len;
+            self._ptr += self._len;
+            self._len = 0;
+            return rune;
+        }
+
+        self._ptr += l;
+        self._len -= l;
+        rune._len = l;
+        return rune;
+    }
+
+    /*
+     * @dev Returns the first rune in the slice, advancing the slice to point
+     *      to the next rune.
+     * @param self The slice to operate on.
+     * @return A slice containing only the first rune from `self`.
+     */
+    function nextRune(slice self) internal pure returns (slice ret) {
+        nextRune(self, ret);
+    }
+
+    /*
+     * @dev Returns the number of the first codepoint in the slice.
+     * @param self The slice to operate on.
+     * @return The number of the first codepoint in the slice.
+     */
+    function ord(slice self) internal pure returns (uint ret) {
+        if (self._len == 0) {
+            return 0;
+        }
+
+        uint word;
+        uint length;
+        uint divisor = 2 ** 248;
+
+        // Load the rune into the MSBs of b
+        assembly { word:= mload(mload(add(self, 32))) }
+        uint b = word / divisor;
+        if (b < 0x80) {
+            ret = b;
+            length = 1;
+        } else if(b < 0xE0) {
+            ret = b & 0x1F;
+            length = 2;
+        } else if(b < 0xF0) {
+            ret = b & 0x0F;
+            length = 3;
+        } else {
+            ret = b & 0x07;
+            length = 4;
+        }
+
+        // Check for truncated codepoints
+        if (length > self._len) {
+            return 0;
+        }
+
+        for (uint i = 1; i < length; i++) {
+            divisor = divisor / 256;
+            b = (word / divisor) & 0xFF;
+            if (b & 0xC0 != 0x80) {
+                // Invalid UTF-8 sequence
+                return 0;
+            }
+            ret = (ret * 64) | (b & 0x3F);
+        }
+
+        return ret;
+    }
+
+    /*
+     * @dev Returns the keccak-256 hash of the slice.
+     * @param self The slice to hash.
+     * @return The hash of the slice.
+     */
+    function keccak(slice self) internal pure returns (bytes32 ret) {
+        assembly {
+            ret := keccak256(mload(add(self, 32)), mload(self))
+        }
+    }
+
+    /*
+     * @dev Returns true if `self` starts with `needle`.
+     * @param self The slice to operate on.
+     * @param needle The slice to search for.
+     * @return True if the slice starts with the provided text, false otherwise.
+     */
+    function startsWith(slice self, slice needle) internal pure returns (bool) {
+        if (self._len < needle._len) {
+            return false;
+        }
+
+        if (self._ptr == needle._ptr) {
+            return true;
+        }
+
+        bool equal;
+        assembly {
+            let length := mload(needle)
+            let selfptr := mload(add(self, 0x20))
+            let needleptr := mload(add(needle, 0x20))
+            equal := eq(keccak256(selfptr, length), keccak256(needleptr, length))
+        }
+        return equal;
+    }
+
+    /*
+     * @dev If `self` starts with `needle`, `needle` is removed from the
+     *      beginning of `self`. Otherwise, `self` is unmodified.
+     * @param self The slice to operate on.
+     * @param needle The slice to search for.
+     * @return `self`
+     */
+    function beyond(slice self, slice needle) internal pure returns (slice) {
+        if (self._len < needle._len) {
+            return self;
+        }
+
+        bool equal = true;
+        if (self._ptr != needle._ptr) {
+            assembly {
+                let length := mload(needle)
+                let selfptr := mload(add(self, 0x20))
+                let needleptr := mload(add(needle, 0x20))
+                equal := eq(sha3(selfptr, length), sha3(needleptr, length))
+            }
+        }
+
+        if (equal) {
+            self._len -= needle._len;
+            self._ptr += needle._len;
+        }
+
+        return self;
+    }
+
+    /*
+     * @dev Returns true if the slice ends with `needle`.
+     * @param self The slice to operate on.
+     * @param needle The slice to search for.
+     * @return True if the slice starts with the provided text, false otherwise.
+     */
+    function endsWith(slice self, slice needle) internal pure returns (bool) {
+        if (self._len < needle._len) {
+            return false;
+        }
+
+        uint selfptr = self._ptr + self._len - needle._len;
+
+        if (selfptr == needle._ptr) {
+            return true;
+        }
+
+        bool equal;
+        assembly {
+            let length := mload(needle)
+            let needleptr := mload(add(needle, 0x20))
+            equal := eq(keccak256(selfptr, length), keccak256(needleptr, length))
+        }
+
+        return equal;
+    }
+
+    /*
+     * @dev If `self` ends with `needle`, `needle` is removed from the
+     *      end of `self`. Otherwise, `self` is unmodified.
+     * @param self The slice to operate on.
+     * @param needle The slice to search for.
+     * @return `self`
+     */
+    function until(slice self, slice needle) internal pure returns (slice) {
+        if (self._len < needle._len) {
+            return self;
+        }
+
+        uint selfptr = self._ptr + self._len - needle._len;
+        bool equal = true;
+        if (selfptr != needle._ptr) {
+            assembly {
+                let length := mload(needle)
+                let needleptr := mload(add(needle, 0x20))
+                equal := eq(keccak256(selfptr, length), keccak256(needleptr, length))
+            }
+        }
+
+        if (equal) {
+            self._len -= needle._len;
+        }
+
+        return self;
+    }
+
+    event log_bytemask(bytes32 mask);
+
+    // Returns the memory address of the first byte of the first occurrence of
+    // `needle` in `self`, or the first byte after `self` if not found.
+    function findPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr) private pure returns (uint) {
+        uint ptr = selfptr;
+        uint idx;
+
+        if (needlelen <= selflen) {
+            if (needlelen <= 32) {
+                bytes32 mask = bytes32(~(2 ** (8 * (32 - needlelen)) - 1));
+
+                bytes32 needledata;
+                assembly { needledata := and(mload(needleptr), mask) }
+
+                uint end = selfptr + selflen - needlelen;
+                bytes32 ptrdata;
+                assembly { ptrdata := and(mload(ptr), mask) }
+
+                while (ptrdata != needledata) {
+                    if (ptr >= end)
+                        return selfptr + selflen;
+                    ptr++;
+                    assembly { ptrdata := and(mload(ptr), mask) }
+                }
+                return ptr;
+            } else {
+                // For long needles, use hashing
+                bytes32 hash;
+                assembly { hash := sha3(needleptr, needlelen) }
+
+                for (idx = 0; idx <= selflen - needlelen; idx++) {
+                    bytes32 testHash;
+                    assembly { testHash := sha3(ptr, needlelen) }
+                    if (hash == testHash)
+                        return ptr;
+                    ptr += 1;
+                }
+            }
+        }
+        return selfptr + selflen;
+    }
+
+    // Returns the memory address of the first byte after the last occurrence of
+    // `needle` in `self`, or the address of `self` if not found.
+    function rfindPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr) private pure returns (uint) {
+        uint ptr;
+
+        if (needlelen <= selflen) {
+            if (needlelen <= 32) {
+                bytes32 mask = bytes32(~(2 ** (8 * (32 - needlelen)) - 1));
+
+                bytes32 needledata;
+                assembly { needledata := and(mload(needleptr), mask) }
+
+                ptr = selfptr + selflen - needlelen;
+                bytes32 ptrdata;
+                assembly { ptrdata := and(mload(ptr), mask) }
+
+                while (ptrdata != needledata) {
+                    if (ptr <= selfptr)
+                        return selfptr;
+                    ptr--;
+                    assembly { ptrdata := and(mload(ptr), mask) }
+                }
+                return ptr + needlelen;
+            } else {
+                // For long needles, use hashing
+                bytes32 hash;
+                assembly { hash := sha3(needleptr, needlelen) }
+                ptr = selfptr + (selflen - needlelen);
+                while (ptr >= selfptr) {
+                    bytes32 testHash;
+                    assembly { testHash := sha3(ptr, needlelen) }
+                    if (hash == testHash)
+                        return ptr + needlelen;
+                    ptr -= 1;
+                }
+            }
+        }
+        return selfptr;
+    }
+
+    /*
+     * @dev Modifies `self` to contain everything from the first occurrence of
+     *      `needle` to the end of the slice. `self` is set to the empty slice
+     *      if `needle` is not found.
+     * @param self The slice to search and modify.
+     * @param needle The text to search for.
+     * @return `self`.
+     */
+    function find(slice self, slice needle) internal pure returns (slice) {
+        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        self._len -= ptr - self._ptr;
+        self._ptr = ptr;
+        return self;
+    }
+
+    /*
+     * @dev Modifies `self` to contain the part of the string from the start of
+     *      `self` to the end of the first occurrence of `needle`. If `needle`
+     *      is not found, `self` is set to the empty slice.
+     * @param self The slice to search and modify.
+     * @param needle The text to search for.
+     * @return `self`.
+     */
+    function rfind(slice self, slice needle) internal pure returns (slice) {
+        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        self._len = ptr - self._ptr;
+        return self;
+    }
+
+    /*
+     * @dev Splits the slice, setting `self` to everything after the first
+     *      occurrence of `needle`, and `token` to everything before it. If
+     *      `needle` does not occur in `self`, `self` is set to the empty slice,
+     *      and `token` is set to the entirety of `self`.
+     * @param self The slice to split.
+     * @param needle The text to search for in `self`.
+     * @param token An output parameter to which the first token is written.
+     * @return `token`.
+     */
+    function split(slice self, slice needle, slice token) internal pure returns (slice) {
+        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        token._ptr = self._ptr;
+        token._len = ptr - self._ptr;
+        if (ptr == self._ptr + self._len) {
+            // Not found
+            self._len = 0;
+        } else {
+            self._len -= token._len + needle._len;
+            self._ptr = ptr + needle._len;
+        }
+        return token;
+    }
+
+    /*
+     * @dev Splits the slice, setting `self` to everything after the first
+     *      occurrence of `needle`, and returning everything before it. If
+     *      `needle` does not occur in `self`, `self` is set to the empty slice,
+     *      and the entirety of `self` is returned.
+     * @param self The slice to split.
+     * @param needle The text to search for in `self`.
+     * @return The part of `self` up to the first occurrence of `delim`.
+     */
+    function split(slice self, slice needle) internal pure returns (slice token) {
+        split(self, needle, token);
+    }
+
+    /*
+     * @dev Splits the slice, setting `self` to everything before the last
+     *      occurrence of `needle`, and `token` to everything after it. If
+     *      `needle` does not occur in `self`, `self` is set to the empty slice,
+     *      and `token` is set to the entirety of `self`.
+     * @param self The slice to split.
+     * @param needle The text to search for in `self`.
+     * @param token An output parameter to which the first token is written.
+     * @return `token`.
+     */
+    function rsplit(slice self, slice needle, slice token) internal pure returns (slice) {
+        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        token._ptr = ptr;
+        token._len = self._len - (ptr - self._ptr);
+        if (ptr == self._ptr) {
+            // Not found
+            self._len = 0;
+        } else {
+            self._len -= token._len + needle._len;
+        }
+        return token;
+    }
+
+    /*
+     * @dev Splits the slice, setting `self` to everything before the last
+     *      occurrence of `needle`, and returning everything after it. If
+     *      `needle` does not occur in `self`, `self` is set to the empty slice,
+     *      and the entirety of `self` is returned.
+     * @param self The slice to split.
+     * @param needle The text to search for in `self`.
+     * @return The part of `self` after the last occurrence of `delim`.
+     */
+    function rsplit(slice self, slice needle) internal pure returns (slice token) {
+        rsplit(self, needle, token);
+    }
+
+    /*
+     * @dev Counts the number of nonoverlapping occurrences of `needle` in `self`.
+     * @param self The slice to search.
+     * @param needle The text to search for in `self`.
+     * @return The number of occurrences of `needle` found in `self`.
+     */
+    function count(slice self, slice needle) internal pure returns (uint cnt) {
+        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) + needle._len;
+        while (ptr <= self._ptr + self._len) {
+            cnt++;
+            ptr = findPtr(self._len - (ptr - self._ptr), ptr, needle._len, needle._ptr) + needle._len;
+        }
+    }
+
+    /*
+     * @dev Returns True if `self` contains `needle`.
+     * @param self The slice to search.
+     * @param needle The text to search for in `self`.
+     * @return True if `needle` is found in `self`, false otherwise.
+     */
+    function contains(slice self, slice needle) internal pure returns (bool) {
+        return rfindPtr(self._len, self._ptr, needle._len, needle._ptr) != self._ptr;
+    }
+
+    /*
+     * @dev Returns a newly allocated string containing the concatenation of
+     *      `self` and `other`.
+     * @param self The first slice to concatenate.
+     * @param other The second slice to concatenate.
+     * @return The concatenation of the two strings.
+     */
+    function concat(slice self, slice other) internal pure returns (string) {
+        string memory ret = new string(self._len + other._len);
+        uint retptr;
+        assembly { retptr := add(ret, 32) }
+        memcpy(retptr, self._ptr, self._len);
+        memcpy(retptr + self._len, other._ptr, other._len);
+        return ret;
+    }
+
+    /*
+     * @dev Joins an array of slices, using `self` as a delimiter, returning a
+     *      newly allocated string.
+     * @param self The delimiter to use.
+     * @param parts A list of slices to join.
+     * @return A newly allocated string containing all the slices in `parts`,
+     *         joined with `self`.
+     */
+    function join(slice self, slice[] parts) internal pure returns (string) {
+        if (parts.length == 0)
+            return "";
+
+        uint length = self._len * (parts.length - 1);
+        for(uint i = 0; i < parts.length; i++)
+            length += parts[i]._len;
+
+        string memory ret = new string(length);
+        uint retptr;
+        assembly { retptr := add(ret, 32) }
+
+        for(i = 0; i < parts.length; i++) {
+            memcpy(retptr, parts[i]._ptr, parts[i]._len);
+            retptr += parts[i]._len;
+            if (i < parts.length - 1) {
+                memcpy(retptr, self._ptr, self._len);
+                retptr += self._len;
+            }
+        }
+
+        return ret;
+    }
+}

--- a/test/ENSLib.js
+++ b/test/ENSLib.js
@@ -1,7 +1,7 @@
 const FIFSRegistrar = artifacts.require('FIFSRegistrar.sol');
 const ENS = artifacts.require('ENSRegistry.sol');
 const ENSLib = artifacts.require('ENSLib.sol');
-const TestRegistryLib = artifacts.require('TestRegistryLib.sol');
+const TestENSLib = artifacts.require('TestENSLib.sol');
 const PublicResolver = artifacts.require('PublicResolver.sol');
 
 const utils = require('./helpers/Utils.js');
@@ -15,8 +15,8 @@ contract('ENSLib', function (accounts) {
     beforeEach(async () => {
         ens = await ENS.new();
         const ensLib = await ENSLib.new();
-        TestRegistryLib.link('ENSLib', ensLib.address);
-        testRegistryLib = await TestRegistryLib.new(ens.address);
+        TestENSLib.link('ENSLib', ensLib.address);
+        testENSLib = await TestENSLib.new(ens.address);
 
         await ens.setSubnodeOwner(0, web3.sha3('eth'), accounts[0], {from: accounts[0]});
         registrar = await FIFSRegistrar.new(ens.address, namehash('eth'));
@@ -33,31 +33,31 @@ contract('ENSLib', function (accounts) {
     });
 
     it('should get the right hashname of subnode', async () => {
-      assert.equal(await testRegistryLib.hashname('testdomain.eth'), namehash('testdomain.eth'));
+      assert.equal(await testENSLib.hashname('testdomain.eth'), namehash('testdomain.eth'));
     });
 
     it('should get the right info of ens node by namehash', async () => {
-      assert.equal(await testRegistryLib.owner(namehash('eth')), registrar.address);
-      assert.equal(await testRegistryLib.resolver(namehash('eth')), '0x0000000000000000000000000000000000000000');
-      assert.equal(await testRegistryLib.ttl(namehash('eth')), 0);
+      assert.equal(await testENSLib.owner(namehash('eth')), registrar.address);
+      assert.equal(await testENSLib.resolver(namehash('eth')), '0x0000000000000000000000000000000000000000');
+      assert.equal(await testENSLib.ttl(namehash('eth')), 0);
     });
 
     it('should get the right info of ens node by string', async () => {
-      assert.equal(await testRegistryLib.ownerByENSName('eth'), registrar.address);
-      assert.equal(await testRegistryLib.resolverByENSName('eth'), '0x0000000000000000000000000000000000000000');
-      assert.equal(await testRegistryLib.ttlByENSName('eth'), 0);
+      assert.equal(await testENSLib.ownerByENSName('eth'), registrar.address);
+      assert.equal(await testENSLib.resolverByENSName('eth'), '0x0000000000000000000000000000000000000000');
+      assert.equal(await testENSLib.ttlByENSName('eth'), 0);
     });
 
     it('should get the right info of ens subnode by namehash', async () => {
-      assert.equal(await testRegistryLib.owner(namehash('testdomain.eth')), accounts[1]);
-      assert.equal(await testRegistryLib.resolver(namehash('testdomain.eth')), accounts[2]);
-      assert.equal(await testRegistryLib.ttl(namehash('testdomain.eth')), 10);
+      assert.equal(await testENSLib.owner(namehash('testdomain.eth')), accounts[1]);
+      assert.equal(await testENSLib.resolver(namehash('testdomain.eth')), accounts[2]);
+      assert.equal(await testENSLib.ttl(namehash('testdomain.eth')), 10);
     });
 
     it('should get the right info of ens subnode by string', async () => {
-      assert.equal(await testRegistryLib.ownerByENSName('testdomain.eth'), accounts[1]);
-      assert.equal(await testRegistryLib.resolverByENSName('testdomain.eth'), accounts[2]);
-      assert.equal(await testRegistryLib.ttlByENSName('testdomain.eth'), 10);
+      assert.equal(await testENSLib.ownerByENSName('testdomain.eth'), accounts[1]);
+      assert.equal(await testENSLib.resolverByENSName('testdomain.eth'), accounts[2]);
+      assert.equal(await testENSLib.ttlByENSName('testdomain.eth'), 10);
     });
 
 });

--- a/test/ENSLib.js
+++ b/test/ENSLib.js
@@ -22,23 +22,42 @@ contract('ENSLib', function (accounts) {
         registrar = await FIFSRegistrar.new(ens.address, namehash('eth'));
         await ens.setOwner(namehash('eth'), registrar.address, {from: accounts[0]});
 
+        await registrar.register(web3Utils.sha3('testdomain'), accounts[1], {from: accounts[0]});
+        await ens.setResolver(namehash('testdomain.eth'), accounts[2], {from: accounts[1]});
+        await ens.setTTL(namehash('testdomain.eth'), 10, {from: accounts[1]});
     });
 
-    it('should get the right info of ens subnode', async () => {
-
-      await registrar.register(web3Utils.sha3('testdomain'), accounts[1], {from: accounts[0]});
-      await ens.setResolver(namehash('testdomain.eth'), accounts[2], {from: accounts[1]});
-      await ens.setTTL(namehash('testdomain.eth'), 10, {from: accounts[1]});
-
-      assert.equal(await ens.owner(namehash('eth')), registrar.address);
+    it('should get the right owner of subnode', async () => {
       assert.equal(await ens.owner(namehash('eth')), registrar.address);
       assert.equal(await ens.owner(namehash('testdomain.eth')), accounts[1]);
-      assert.equal(await testRegistryLib.ensAddr(), ens.address);
+    });
+
+    it('should get the right hashname of subnode', async () => {
       assert.equal(await testRegistryLib.hashname('testdomain.eth'), namehash('testdomain.eth'));
+    });
+
+    it('should get the right info of ens node by namehash', async () => {
+      assert.equal(await testRegistryLib.owner(namehash('eth')), registrar.address);
+      assert.equal(await testRegistryLib.resolver(namehash('eth')), '0x0000000000000000000000000000000000000000');
+      assert.equal(await testRegistryLib.ttl(namehash('eth')), 0);
+    });
+
+    it('should get the right info of ens node by string', async () => {
+      assert.equal(await testRegistryLib.ownerByENSName('eth'), registrar.address);
+      assert.equal(await testRegistryLib.resolverByENSName('eth'), '0x0000000000000000000000000000000000000000');
+      assert.equal(await testRegistryLib.ttlByENSName('eth'), 0);
+    });
+
+    it('should get the right info of ens subnode by namehash', async () => {
       assert.equal(await testRegistryLib.owner(namehash('testdomain.eth')), accounts[1]);
-      assert.equal(await testRegistryLib.ownerByENSName('testdomain.eth'), accounts[1]);
       assert.equal(await testRegistryLib.resolver(namehash('testdomain.eth')), accounts[2]);
       assert.equal(await testRegistryLib.ttl(namehash('testdomain.eth')), 10);
+    });
+
+    it('should get the right info of ens subnode by string', async () => {
+      assert.equal(await testRegistryLib.ownerByENSName('testdomain.eth'), accounts[1]);
+      assert.equal(await testRegistryLib.resolverByENSName('testdomain.eth'), accounts[2]);
+      assert.equal(await testRegistryLib.ttlByENSName('testdomain.eth'), 10);
     });
 
 });

--- a/test/ENSLib.js
+++ b/test/ENSLib.js
@@ -1,0 +1,44 @@
+const FIFSRegistrar = artifacts.require('FIFSRegistrar.sol');
+const ENS = artifacts.require('ENSRegistry.sol');
+const ENSLib = artifacts.require('ENSLib.sol');
+const TestRegistryLib = artifacts.require('TestRegistryLib.sol');
+const PublicResolver = artifacts.require('PublicResolver.sol');
+
+const utils = require('./helpers/Utils.js');
+const web3Utils = require('web3-utils');
+const namehash = require('eth-ens-namehash');
+
+contract('ENSLib', function (accounts) {
+
+    let resolver, registrar, ens;
+
+    beforeEach(async () => {
+        ens = await ENS.new();
+        const ensLib = await ENSLib.new();
+        TestRegistryLib.link('ENSLib', ensLib.address);
+        testRegistryLib = await TestRegistryLib.new(ens.address);
+
+        await ens.setSubnodeOwner(0, web3.sha3('eth'), accounts[0], {from: accounts[0]});
+        registrar = await FIFSRegistrar.new(ens.address, namehash('eth'));
+        await ens.setOwner(namehash('eth'), registrar.address, {from: accounts[0]});
+
+    });
+
+    it('should get the right info of ens subnode', async () => {
+
+      await registrar.register(web3Utils.sha3('testdomain'), accounts[1], {from: accounts[0]});
+      await ens.setResolver(namehash('testdomain.eth'), accounts[2], {from: accounts[1]});
+      await ens.setTTL(namehash('testdomain.eth'), 10, {from: accounts[1]});
+
+      assert.equal(await ens.owner(namehash('eth')), registrar.address);
+      assert.equal(await ens.owner(namehash('eth')), registrar.address);
+      assert.equal(await ens.owner(namehash('testdomain.eth')), accounts[1]);
+      assert.equal(await testRegistryLib.ensAddr(), ens.address);
+      assert.equal(await testRegistryLib.hashname('testdomain.eth'), namehash('testdomain.eth'));
+      assert.equal(await testRegistryLib.owner(namehash('testdomain.eth')), accounts[1]);
+      assert.equal(await testRegistryLib.ownerByENSName('testdomain.eth'), accounts[1]);
+      assert.equal(await testRegistryLib.resolver(namehash('testdomain.eth')), accounts[2]);
+      assert.equal(await testRegistryLib.ttl(namehash('testdomain.eth')), 10);
+    });
+
+});


### PR DESCRIPTION
Add a ENS library to access to ENS Registry information on the smart contract level. It uses the strings library to split the namehash received in string type and calculate the namehash of the ens.
Using the namehash calculated the smart contracts that use this library can get the owner, resolver and ttl of ens directly from the registry.