### PR TITLE
use "then" combinator to map over Promise value

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -38,7 +38,7 @@ function deployFIFSRegistrar(deployer, tld) {
     })
     .then(function() {
       // Transfer the owner of the `rootNode` to the FIFSRegistrar
-      ENS.at(ENS.address).setSubnodeOwner('0x0', rootNode.sha3, FIFSRegistrar.address);
+      return ENS.at(ENS.address).then((c) => c.setSubnodeOwner('0x0', rootNode.sha3, FIFSRegistrar.address));
     });
 }
 
@@ -60,7 +60,7 @@ function deployAuctionRegistrar(deployer, tld) {
     })
     .then(function() {
       // Transfer the owner of the `rootNode` to the HashRegistrar
-      ENS.at(ENS.address).setSubnodeOwner('0x0', rootNode.sha3, Registrar.address);
+      return ENS.at(ENS.address).then((c) => c.setSubnodeOwner('0x0', rootNode.sha3, Registrar.address));
     });
 }
 


### PR DESCRIPTION
According to **Truffle** spec of `<Contract>.at(address)` method, we have _thenable_ object as return value, so that one needs to map over returned Promise now. https://github.com/trufflesuite/truffle/blob/76f1fb284845210d3cd9983b09e3e7d75f077090/packages/truffle-contract/README.md#mycontractataddress

Closes https://github.com/ensdomains/ens/issues/325