### PR TITLE
Adding interface to reverse registrar

### DIFF
--- a/contracts/IReverseRegistrar.sol
+++ b/contracts/IReverseRegistrar.sol
@@ -1,0 +1,10 @@
+pragma solidity >=0.4.24;
+
+interface IReverseRegistrar {
+
+    function claim(address owner) external returns (bytes32);
+    function claimWithResolver(address owner, address resolver) external returns (bytes32);
+    function setName(string calldata name) external returns (bytes32);
+    function node(address addr) external pure returns (bytes32);
+
+}

--- a/contracts/ReverseRegistrar.sol
+++ b/contracts/ReverseRegistrar.sol
@@ -1,12 +1,13 @@
 pragma solidity ^0.5.0;
 
 import "./ENS.sol";
+import "./IReverseRegistrar.sol";
 
 contract Resolver {
     function setName(bytes32 node, string memory name) public;
 }
 
-contract ReverseRegistrar {
+contract ReverseRegistrar is IReverseRegistrar{
     // namehash('addr.reverse')
     bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
@@ -28,7 +29,7 @@ contract ReverseRegistrar {
             oldRegistrar.claim(msg.sender);
         }
     }
-    
+
     /**
      * @dev Transfers ownership of the reverse ENS record associated with the
      *      calling account.


### PR DESCRIPTION
With solidity 0.6.0 introducing breaking changes, it is not possible for smart contract using solidity 0.6.0 to import contract sources using ^0.5.0 such as those in this repository.

A solution is to, rather then importing the actual source, rely on an interface with pragma >=0.4.24 such as `ENS.sol`. However, there isn't such an interface for the reverse registrar.

This PR solves this by adding such an interface that can be imported by smart contract using ^0.5.0 of ^0.6.0