### PR TITLE
fix to use namehash hash method

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -15,7 +15,7 @@ const namehash = require('eth-ens-namehash');
  */
 function getRootNodeFromTLD(tld) {
   return {
-    namehash: namehash(tld),
+    namehash: namehash.hash(tld),
     sha3: web3.sha3(tld)
   };
 }


### PR DESCRIPTION
fix for error when trying to compile

`TypeError: namehash is not a function`